### PR TITLE
fix(docker): use monorepo root context to resolve @progresapp/shared

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+**/node_modules/
+.git/
+mobile/
+backend/
+postgres-data/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,8 @@ services:
 
   frontend:
     build:
-      context: ./frontend
+      context: .
+      dockerfile: frontend/Dockerfile
       args:
         - PUBLIC_API_BASE_URL=${PUBLIC_API_BASE_URL}
     container_name: flacow-frontend

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,27 +1,33 @@
-FROM node:lts AS base
+FROM node:lts AS builder
 WORKDIR /app
 
+# Copy workspace manifest files
 COPY package.json package-lock.json ./
+# Copy shared package (workspace dependency)
+COPY packages/shared/ ./packages/shared/
+# Copy frontend source
+COPY frontend/ ./frontend/
 
-FROM base AS prod-deps
-RUN npm install --production
+# Install all workspace deps from root (resolves @progresapp/shared locally)
+RUN npm ci
 
-FROM base AS build-deps
-RUN npm install --production=false
-
-FROM build-deps AS build
-COPY . .
-
-# Configura las variables de entorno en la etapa de construcción
 ARG PUBLIC_API_BASE_URL
 ENV PUBLIC_API_BASE_URL=${PUBLIC_API_BASE_URL}
 
+WORKDIR /app/frontend
 RUN npm run build
 
-FROM base AS runtime
-COPY --from=prod-deps /app/node_modules ./node_modules
-COPY --from=build /app/dist ./dist
+FROM node:lts-slim AS runtime
+WORKDIR /app
 
+# Copy built output
+COPY --from=builder /app/frontend/dist ./frontend/dist
+# Copy workspace node_modules (includes @progresapp/shared symlink target)
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/packages/shared ./packages/shared
+COPY --from=builder /app/frontend/package.json ./frontend/
+
+WORKDIR /app/frontend
 ENV HOST=0.0.0.0
 ENV PORT=4321
 EXPOSE 4321


### PR DESCRIPTION
## Problem

The frontend Docker build was failing with `npm error 404 Not Found - GET @progresapp/shared` because the build context was `./frontend`, which has no access to `packages/shared/` (a local npm workspace package).

## Fix

- `docker-compose.yml`: change frontend build context from `./frontend` to `.` (monorepo root), add `dockerfile: frontend/Dockerfile`
- `frontend/Dockerfile`: rewrite to copy `packages/shared/` + run `npm ci` from root so workspaces resolve correctly
- `.dockerignore`: exclude `mobile/`, `backend/`, `node_modules/`, `.git/` from the root build context

## Why this works

`npm ci` at the monorepo root installs all workspaces including `@progresapp/shared` as a local symlink. The Astro build then bundles it into `dist/`, making the runtime image self-contained.