### PR TITLE
fix(deploy): git reset --hard before pull to handle dirty server working tree

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,7 +30,8 @@ jobs:
           script: |
             set -e
             cd ~/docker/github/progresapp-flacow
-            git pull origin main
+            git fetch origin main
+            git reset --hard origin/main
             docker compose up -d --build
             docker image prune -f
             echo "Deploy OK — $(date)"


### PR DESCRIPTION
The server had local changes to docker-compose.yml that blocked git pull. Replace with git fetch + git reset --hard origin/main so the server always matches main regardless of local state.