### PR TITLE
fix(deploy): docker compose down before up to release ports

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,6 +32,7 @@ jobs:
             cd ~/docker/github/progresapp-flacow
             git fetch origin main
             git reset --hard origin/main
+            docker compose down --remove-orphans
             docker compose up -d --build
             docker image prune -f
             echo "Deploy OK — $(date)"


### PR DESCRIPTION
The server had a stale nginx container holding port 81 from a previous failed deploy. Adding docker compose down --remove-orphans before up ensures all ports are released and orphaned containers are cleaned up before starting fresh.