### PR TITLE
fix(deploy): stop any container holding port 81 before compose up

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,6 +33,7 @@ jobs:
             git fetch origin main
             git reset --hard origin/main
             docker compose down --remove-orphans
+            docker ps -q --filter "publish=81" | xargs -r docker stop
             docker compose up -d --build
             docker image prune -f
             echo "Deploy OK — $(date)"


### PR DESCRIPTION
Port 81 was still allocated after docker compose down because a container from a previous failed deploy was not recognized as part of this compose project. Adding explicit docker stop for any container publishing port 81 ensures a clean start.