### PR TITLE
fix(docker): join proxy network instead of binding port 81 on host

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,8 +38,15 @@ services:
     container_name: flacow-nginx
     volumes:
       - ./nginx.conf:/etc/nginx/conf.d/default.conf
-    ports:
-      - "81:80"  # Solo expone el puerto del Nginx
+    expose:
+      - 80
     depends_on:
       - frontend
       - backend
+    networks:
+      - default
+      - proxy
+
+networks:
+  proxy:
+    external: true


### PR DESCRIPTION
NPM routes flacow.bfmu.dev → flacow-nginx:80 by container name via the proxy Docker network. The ports binding was unnecessary and conflicted with NPM's admin panel on port 81. Fix: expose port 80 internally + join the external proxy network.