### PR TITLE
release: 0.2.5 — fix docker proxy network instead of port 81 binding

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,8 +38,15 @@ services:
     container_name: flacow-nginx
     volumes:
       - ./nginx.conf:/etc/nginx/conf.d/default.conf
-    ports:
-      - "81:80"  # Solo expone el puerto del Nginx
+    expose:
+      - 80
     depends_on:
       - frontend
       - backend
+    networks:
+      - default
+      - proxy
+
+networks:
+  proxy:
+    external: true


### PR DESCRIPTION
Release 0.2.5 — fix docker proxy network instead of port 81 binding