### PR TITLE
fix(deploy): remove kill port 81 command

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,7 +33,6 @@ jobs:
             git fetch origin main
             git reset --hard origin/main
             docker compose down --remove-orphans
-            docker ps -q --filter "publish=81" | xargs -r docker stop
             docker compose up -d --build
             docker image prune -f
             echo "Deploy OK — $(date)"


### PR DESCRIPTION
The kill-port-81 command was added as a workaround for the port conflict but is no longer needed after switching to the proxy network. It was killing nginx-proxy-manager on every deploy.