### PR TITLE
release: 0.2.6 — fix deploy: remove kill port 81 command that was taking down nginx-proxy-manager

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,7 +33,6 @@ jobs:
             git fetch origin main
             git reset --hard origin/main
             docker compose down --remove-orphans
-            docker ps -q --filter "publish=81" | xargs -r docker stop
             docker compose up -d --build
             docker image prune -f
             echo "Deploy OK — $(date)"


### PR DESCRIPTION
Release 0.2.6 — fix deploy: remove kill port 81 command that was taking down nginx-proxy-manager