### PR TITLE
fix(frontend): ensure axios client initialized before any route renders

### DIFF
--- a/frontend/src/react/components/app.tsx
+++ b/frontend/src/react/components/app.tsx
@@ -1,5 +1,6 @@
 import { createBrowserRouter, RouterProvider } from "react-router-dom";
 import React, { useMemo, lazy, Suspense } from "react";
+import "../../lib/axios";
 import LayoutReact from "./LayoutReact";
 import Loading from "./Loading";
 import ErrorFallback from "./ErrorFallback";


### PR DESCRIPTION
AuthCallback was failing with auth_failed because setApiClient had not been called before userInfoRequest() executed. Importing axios.ts in app.tsx guarantees the axios singleton is ready before any route component mounts.