### PR TITLE
feat(landing): add Android APK download section

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,6 +38,7 @@ services:
     container_name: flacow-nginx
     volumes:
       - ./nginx.conf:/etc/nginx/conf.d/default.conf
+      - ./downloads:/var/www/downloads:ro
     expose:
       - 80
     depends_on:

--- a/frontend/src/pages/index.astro
+++ b/frontend/src/pages/index.astro
@@ -58,6 +58,36 @@ import Layout from '../layouts/Layout.astro';
       </div>
     </section>
 
+    <!-- Download App -->
+    <section class="max-w-6xl mx-auto px-6 py-16">
+      <div class="rounded-2xl border border-azure/30 bg-gradient-to-br from-neutral-900 to-neutral-800 p-10 flex flex-col md:flex-row items-center justify-between gap-8">
+        <div>
+          <span class="inline-block px-3 py-1 rounded-full bg-azure/20 text-azure text-xs font-semibold tracking-wide mb-3">BETA ABIERTA</span>
+          <h2 class="text-2xl md:text-3xl font-bold">Descargá la app para Android</h2>
+          <p class="mt-2 text-gray-400 max-w-md">Llevá tu entrenamiento al bolsillo. Registrá series, pesos y descansá con el timer — todo desde tu celular.</p>
+          <div class="mt-6 flex flex-wrap gap-3 items-center">
+            <a
+              href="/downloads/flacow.apk"
+              download
+              class="inline-flex items-center gap-2 px-6 py-3 rounded-xl bg-azure text-white font-semibold hover:bg-[#1565c0] transition-colors"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
+              </svg>
+              Descargar APK
+            </a>
+            <span class="text-xs text-gray-500">Android 8.0+ · ~25 MB</span>
+          </div>
+          <p class="mt-4 text-xs text-gray-500">Al instalar, habilitá "Instalar desde fuentes desconocidas" en Ajustes → Seguridad.</p>
+        </div>
+        <div class="flex-shrink-0">
+          <div class="w-32 h-32 rounded-2xl bg-neutral-700 border border-white/10 flex items-center justify-center">
+            <img src="/favicon.svg" alt="FLACOW App" class="w-20 h-20 opacity-80" />
+          </div>
+        </div>
+      </div>
+    </section>
+
     <!-- Features -->
     <section class="max-w-6xl mx-auto px-6 py-16">
       <h2 class="text-2xl md:text-3xl font-semibold text-center">Todo lo que necesitas</h2>

--- a/mobile/eas.json
+++ b/mobile/eas.json
@@ -1,5 +1,4 @@
 {
-  "_comment": "EXPO_PUBLIC_API_BASE_URL values below are placeholders. Replace with real backend URLs per environment (see backend/.env.example for CORS_ORIGINS that must allow these origins). development points at a LAN/tunnel URL for Expo Go on a physical device; preview/production point at deployed API hosts.",
   "cli": {
     "version": ">= 13.0.0",
     "appVersionSource": "remote"
@@ -14,14 +13,19 @@
     },
     "preview": {
       "distribution": "internal",
+      "android": {
+        "buildType": "apk"
+      },
       "env": {
-        "EXPO_PUBLIC_API_BASE_URL": "https://staging-api.progresapp.example.com/api"
+        "EXPO_PUBLIC_API_BASE_URL": "https://flacow.bfmu.dev/api",
+        "EXPO_PUBLIC_GOOGLE_CLIENT_ID": "198417734095-7lo4l5oqv09ksrufeo5leteo8u803c8t.apps.googleusercontent.com"
       }
     },
     "production": {
       "autoIncrement": true,
       "env": {
-        "EXPO_PUBLIC_API_BASE_URL": "https://api.progresapp.example.com/api"
+        "EXPO_PUBLIC_API_BASE_URL": "https://flacow.bfmu.dev/api",
+        "EXPO_PUBLIC_GOOGLE_CLIENT_ID": "198417734095-7lo4l5oqv09ksrufeo5leteo8u803c8t.apps.googleusercontent.com"
       }
     }
   },

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,6 +1,13 @@
 server {
     listen 80;
 
+    # Serve APK and static downloads directly from nginx
+    location /downloads/ {
+        alias /var/www/downloads/;
+        add_header Content-Disposition 'attachment';
+        add_header Cache-Control 'no-cache';
+    }
+
     # Proxy para las solicitudes a /api
     location /api/ {
         proxy_pass http://flacow-backend:3000/api/;


### PR DESCRIPTION
Adds a download section to the landing page pointing to /downloads/flacow.apk. Nginx serves the file from a mounted volume. EAS eas.json updated with real prod API URL.