### PR TITLE
fix: use eas build --local so --output flag works in CI

### DIFF
--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Build APK
         working-directory: mobile
-        run: eas build --platform android --profile preview --non-interactive --output /tmp/flacow.apk
+        run: eas build --platform android --profile preview --non-interactive --local --output ${{ github.workspace }}/flacow.apk
 
       - name: Deploy APK to server
         uses: appleboy/ssh-action@v1.2.0
@@ -55,6 +55,5 @@ jobs:
           host: ${{ secrets.DEPLOY_HOST }}
           username: ${{ secrets.DEPLOY_USER }}
           key: ${{ secrets.DEPLOY_SSH_KEY }}
-          source: /tmp/flacow.apk
+          source: flacow.apk
           target: ~/docker/github/progresapp-flacow/downloads/
-          strip_components: 2


### PR DESCRIPTION
## Summary
- `eas build --output` solo funciona para builds locales, no cloud. El workflow fallaba con `--output is allowed only for local builds`.
- Fix: agregado `--local` para que EAS construya el APK directamente en el runner (usa Docker internamente, no requiere Android SDK adicional).
- Cambiada la ruta de salida a `${{ github.workspace }}/flacow.apk` para que el scp-action la encuentre correctamente.

## Test plan
- [ ] El PR pasa CI (lint + build)
- [ ] Después del merge y release → el workflow `build-apk.yml` construye el APK exitosamente
- [ ] El APK queda disponible en `https://flacow.bfmu.dev/downloads/flacow.apk`