### PR TITLE
fix: add eas projectId to app.config.js for CI builds

### DIFF
--- a/mobile/app.config.js
+++ b/mobile/app.config.js
@@ -44,5 +44,8 @@ module.exports = {
   extra: {
     apiBaseUrl: API_BASE_URL,
     googleClientId: GOOGLE_CLIENT_ID,
+    eas: {
+      projectId: "ada4c02f-0e70-4cdd-be6c-fd7eff634095",
+    },
   },
 };


### PR DESCRIPTION
## Summary
- `eas init --force` creó el proyecto en EAS: `@bfmu/progresapp-mobile`
- ProjectId generado: `ada4c02f-0e70-4cdd-be6c-fd7eff634095`
- Como el proyecto usa `app.config.js` dinámico, EAS no puede escribirlo automáticamente — se agrega manualmente en `extra.eas.projectId`
- Sin esto, `eas build --local --non-interactive` falla con "EAS project not configured"

## Test plan
- [ ] CI verde en este PR
- [ ] Merge → release → el workflow `build-apk.yml` construye el APK exitosamente