### PR TITLE
fix: switch to EAS cloud build to avoid local keystore injection bug

### DIFF
--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -37,9 +37,23 @@ jobs:
           eas-version: latest
           token: ${{ secrets.EXPO_TOKEN }}
 
-      - name: Build APK
+      - name: Build APK (EAS Cloud)
         working-directory: mobile
-        run: eas build --platform android --profile preview --non-interactive --local --output ${{ github.workspace }}/flacow.apk
+        run: |
+          BUILD_URL=$(eas build \
+            --platform android \
+            --profile preview \
+            --non-interactive \
+            --json 2>/dev/null | jq -r '.artifacts.buildUrl // empty')
+
+          if [ -z "$BUILD_URL" ]; then
+            echo "::error::No build URL returned from EAS"
+            exit 1
+          fi
+
+          echo "Downloading APK from EAS..."
+          curl -fL "$BUILD_URL" -o "${{ github.workspace }}/flacow.apk"
+          echo "APK ready — $(du -h "${{ github.workspace }}/flacow.apk" | cut -f1)"
 
       - name: Deploy APK to server
         uses: appleboy/ssh-action@v1.2.0


### PR DESCRIPTION
## Summary
- El build local (`--local`) fallaba con `path may not be null or empty string. path=''` en `build.gradle:33` — un bug conocido de `eas-cli-local-build-plugin@20.1.0` al inyectar las credenciales del keystore.
- Solución: usar cloud build de EAS (sin `--local`) y descargar el APK generado usando el URL del JSON output.
- `eas build --json 2>/dev/null | jq -r '.artifacts.buildUrl'` da el download URL después de que el build termina.

## Test plan
- [ ] CI verde en este PR
- [ ] Merge → release → `build-apk.yml` construye APK en la nube y lo sube al servidor
- [ ] `https://flacow.bfmu.dev/downloads/flacow.apk` descargable