### PR TITLE
fix: eas build --json returns array, use .[0].artifacts.buildUrl

### DIFF
--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -44,7 +44,7 @@ jobs:
             --platform android \
             --profile preview \
             --non-interactive \
-            --json 2>/dev/null | jq -r '.artifacts.buildUrl // empty')
+            --json 2>/dev/null | jq -r '.[0].artifacts.buildUrl // empty')
 
           if [ -z "$BUILD_URL" ]; then
             echo "::error::No build URL returned from EAS"


### PR DESCRIPTION
## Summary
El build de EAS completó exitosamente (22 min) pero el paso de descarga falló porque `eas build --json` devuelve un **array** JSON, no un objeto. Cambio `.artifacts.buildUrl` → `.[0].artifacts.buildUrl`.

## Root cause
```
jq: error (at <stdin>:46): Cannot index array with string "artifacts"
```