### PR TITLE
fix: use assembleDebug for preview APK (avoid release signing config)

### DIFF
--- a/mobile/eas.json
+++ b/mobile/eas.json
@@ -14,7 +14,8 @@
     "preview": {
       "distribution": "internal",
       "android": {
-        "buildType": "apk"
+        "buildType": "apk",
+        "gradleCommand": ":app:assembleDebug"
       },
       "env": {
         "EXPO_PUBLIC_API_BASE_URL": "https://flacow.bfmu.dev/api",


### PR DESCRIPTION
## Summary
El EAS cloud build fallaba con `EAS_BUILD_UNKNOWN_GRADLE_ERROR` → `path may not be null or empty string. path=''` en `build.gradle:33`.

Causa: la release signing config usa `KEYSTORE_PATH` que queda vacío durante el prebuild. EAS no lo inyecta correctamente para este setup de monorepo + SDK 51.

Fix: usar `gradleCommand: ":app:assembleDebug"` para el perfil preview. Un APK de debug usa el `debug.keystore` predefinido — no necesita credenciales de release. Perfectamente válido para distribución interna/beta.