### PR TITLE
release: 0.3.9 — fix: use assembleDebug for preview APK to avoid Gradle signing error

### DIFF
--- a/mobile/eas.json
+++ b/mobile/eas.json
@@ -14,7 +14,8 @@
     "preview": {
       "distribution": "internal",
       "android": {
-        "buildType": "apk"
+        "buildType": "apk",
+        "gradleCommand": ":app:assembleDebug"
       },
       "env": {
         "EXPO_PUBLIC_API_BASE_URL": "https://flacow.bfmu.dev/api",


### PR DESCRIPTION
Release 0.3.9 — fix: use assembleDebug for preview APK to avoid Gradle signing error