### PR TITLE
fix: add index.js entry for Expo monorepo compatibility

### DIFF
--- a/mobile/index.js
+++ b/mobile/index.js
@@ -1,0 +1,1 @@
+import 'expo/AppEntry';

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -3,11 +3,11 @@
   "version": "0.0.1",
   "private": true,
   "description": "Progresapp mobile app (React Native + Expo) — workout tracking and rest timer with push notifications",
-  "main": "node_modules/expo/AppEntry.js",
+  "main": "index.js",
   "scripts": {
     "start": "expo start",
-    "android": "expo start --android",
-    "ios": "expo start --ios",
+    "android": "expo run:android",
+    "ios": "expo run:ios",
     "web": "expo start --web",
     "test": "NODE_PATH=./node_modules jest",
     "test:watch": "NODE_PATH=./node_modules jest --watch"


### PR DESCRIPTION
## Root Cause
En npm workspaces, `expo` se hoistea a `node_modules/` raíz del monorepo. `mobile/package.json` tenía `"main": "node_modules/expo/AppEntry.js"` — esa ruta no existe localmente, así que el Gradle `resolveAppEntry` fallaba retornando vacío, causando `file('')` → `path may not be null or empty string. path=''`.

## Fix
- `mobile/package.json`: `"main": "index.js"` (apunta a archivo local)
- `mobile/index.js`: `import 'expo/AppEntry'` (re-exporta el entry de expo)

Esto sigue el patrón oficial de Expo para monorepos con npm workspaces.

## Verificación local
```
$ node -e "require('expo/scripts/resolveAppEntry')" "/path/to/mobile" android absolute
/path/to/mobile/index.js  ✅
```