### PR TITLE
release: 0.4.0 — fix: add index.js entry for Expo monorepo — root cause of Gradle build failure

### DIFF
--- a/mobile/index.js
+++ b/mobile/index.js
@@ -1,0 +1,1 @@
+import 'expo/AppEntry';

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -3,11 +3,11 @@
   "version": "0.0.1",
   "private": true,
   "description": "Progresapp mobile app (React Native + Expo) — workout tracking and rest timer with push notifications",
-  "main": "node_modules/expo/AppEntry.js",
+  "main": "index.js",
   "scripts": {
     "start": "expo start",
-    "android": "expo start --android",
-    "ios": "expo start --ios",
+    "android": "expo run:android",
+    "ios": "expo run:ios",
     "web": "expo start --web",
     "test": "NODE_PATH=./node_modules jest",
     "test:watch": "NODE_PATH=./node_modules jest --watch"


### PR DESCRIPTION
Release 0.4.0 — fix: add index.js entry for Expo monorepo — root cause of Gradle build failure