### PR TITLE
fix: NativeWind metro config, eas.json cleanup, build error visibility

### DIFF
--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -40,14 +40,30 @@ jobs:
       - name: Build APK (EAS Cloud)
         working-directory: mobile
         run: |
-          BUILD_URL=$(eas build \
+          set -eo pipefail
+
+          # Capture JSON on stdout; progress logs go to stderr (visible in GHA)
+          EAS_JSON=$(eas build \
             --platform android \
             --profile preview \
             --non-interactive \
-            --json 2>/dev/null | jq -r '.[0].artifacts.buildUrl // empty')
+            --json 2>&1)
+
+          echo "=== EAS JSON ==="
+          echo "$EAS_JSON"
+          echo "=== END EAS JSON ==="
+
+          BUILD_STATUS=$(echo "$EAS_JSON" | jq -r '.[0].status // "UNKNOWN"' 2>/dev/null || echo "PARSE_ERROR")
+          BUILD_ERROR_CODE=$(echo "$EAS_JSON" | jq -r '.[0].error.errorCode // empty' 2>/dev/null || true)
+          BUILD_ERROR_MSG=$(echo "$EAS_JSON" | jq -r '.[0].error.message // empty' 2>/dev/null || true)
+          BUILD_URL=$(echo "$EAS_JSON" | jq -r '.[0].artifacts.buildUrl // empty' 2>/dev/null || true)
+
+          echo "Build status: $BUILD_STATUS"
+          [ -n "$BUILD_ERROR_CODE" ] && echo "Error code: $BUILD_ERROR_CODE"
+          [ -n "$BUILD_ERROR_MSG" ] && echo "Error: $BUILD_ERROR_MSG"
 
           if [ -z "$BUILD_URL" ]; then
-            echo "::error::No build URL returned from EAS"
+            echo "::error::EAS build failed — status: $BUILD_STATUS, error: $BUILD_ERROR_CODE: $BUILD_ERROR_MSG"
             exit 1
           fi
 

--- a/mobile/.gitignore
+++ b/mobile/.gitignore
@@ -1,0 +1,2 @@
+android/
+ios/

--- a/mobile/eas.json
+++ b/mobile/eas.json
@@ -14,7 +14,6 @@
     "preview": {
       "distribution": "internal",
       "android": {
-        "buildType": "apk",
         "gradleCommand": ":app:assembleDebug"
       },
       "env": {

--- a/mobile/metro.config.js
+++ b/mobile/metro.config.js
@@ -1,0 +1,6 @@
+const { getDefaultConfig } = require("expo/metro-config");
+const { withNativeWind } = require("nativewind/metro");
+
+const config = getDefaultConfig(__dirname);
+
+module.exports = withNativeWind(config, { input: "./global.css" });


### PR DESCRIPTION
## Summary
- Add `mobile/metro.config.js` with `withNativeWind` — required for NativeWind v4 CSS transforms during Metro bundling (Gradle calls Metro via Expo CLI during `assembleDebug`)
- Remove `buildType: "apk"` from `eas.json` preview profile — mutually exclusive with `gradleCommand`, having both may cause unexpected behavior
- Add `mobile/.gitignore` to exclude generated `android/` and `ios/` dirs from git
- Show full EAS JSON output and parse error code/message on build failure for visibility

## Test plan
- [ ] PR CI passes
- [ ] EAS build succeeds with `:app:assembleDebug` and APK deployed to server
- [ ] If still failing, EAS JSON is now visible in GHA logs showing the exact error