### PR TITLE
fix: prevent set -e from swallowing EAS output on build failure

### DIFF
--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -42,12 +42,12 @@ jobs:
         run: |
           set -eo pipefail
 
-          # Capture JSON on stdout; progress logs go to stderr (visible in GHA)
+          # Capture JSON; || true prevents set -e from exiting when EAS returns non-zero (failed build)
           EAS_JSON=$(eas build \
             --platform android \
             --profile preview \
             --non-interactive \
-            --json 2>&1)
+            --json 2>&1) || true
 
           echo "=== EAS JSON ==="
           echo "$EAS_JSON"


### PR DESCRIPTION
## Summary
- `set -eo pipefail` was causing the script to exit when `eas build --json` returned a non-zero exit code (which it does on build failure), before reaching the `echo "=== EAS JSON ==="` lines
- Adding `|| true` after the variable assignment prevents `set -e` from triggering, so we always see the full EAS JSON output regardless of build success/failure

## Test plan
- [ ] On next build failure, the full EAS JSON and parsed error code appear in GHA logs