### PR TITLE
fix(mobile): remove expo-web-browser from plugins array

### DIFF
--- a/mobile/app.config.js
+++ b/mobile/app.config.js
@@ -40,7 +40,7 @@ module.exports = {
   web: {
     favicon: "./assets/favicon.png",
   },
-  plugins: ["expo-secure-store", "expo-web-browser"],
+  plugins: ["expo-secure-store"],
   extra: {
     apiBaseUrl: API_BASE_URL,
     googleClientId: GOOGLE_CLIENT_ID,


### PR DESCRIPTION
## Summary

- `expo-web-browser 13.x` (SDK 51) has no `app.plugin.js`
- When listed in `plugins: ["expo-secure-store", "expo-web-browser"]`, expo prebuild tries to load the package as a config plugin — falling back to `build/WebBrowser.js` which is ESM-only
- This causes Node.js to fail: `Cannot use import statement outside a module` (CJS) or `Cannot find package 'react-native' imported from expo-modules-core` (Node 20 ESM)
- `expo-web-browser` does not need a config plugin — the autolinking system handles the `android/` native code via `useExpoModules()` in `settings.gradle`

## Test plan

- [ ] CI green
- [ ] `expo prebuild` completes with `✔ Finished prebuild` (verified locally)
- [ ] `build-apk` workflow succeeds after merge to main