### PR TITLE
fix(ci): upgrade scp-action to v1 with overwrite flag

### DIFF
--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -73,10 +73,11 @@ jobs:
           script: mkdir -p ~/docker/github/progresapp-flacow/downloads
 
       - name: Upload APK to server
-        uses: appleboy/scp-action@v0.1.7
+        uses: appleboy/scp-action@v1
         with:
           host: ${{ secrets.DEPLOY_HOST }}
           username: ${{ secrets.DEPLOY_USER }}
           key: ${{ secrets.DEPLOY_SSH_KEY }}
           source: flacow.apk
           target: ~/docker/github/progresapp-flacow/downloads/
+          overwrite: true


### PR DESCRIPTION
## Summary

- `appleboy/scp-action@v0.1.7` incorrectly treats ssh-agent `Identity added` output as an error, causing rollback immediately after creating the target folder
- Upgraded to `v1` which fixes this known bug in the underlying drone-scp tool
- Added `overwrite: true` for idempotent re-uploads

## Note

The APK build itself succeeded in the previous run (0.4.6) — 152MB APK generated. Only the upload step failed.