### PR TITLE
fix(ci): replace scp-action with native scp

### DIFF
--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -64,20 +64,17 @@ jobs:
           cp mobile/android/app/build/outputs/apk/debug/app-debug.apk flacow.apk
           echo "APK size: $(du -h flacow.apk | cut -f1)"
 
-      - name: Deploy APK to server
-        uses: appleboy/ssh-action@v1.2.0
-        with:
-          host: ${{ secrets.DEPLOY_HOST }}
-          username: ${{ secrets.DEPLOY_USER }}
-          key: ${{ secrets.DEPLOY_SSH_KEY }}
-          script: mkdir -p ~/docker/github/progresapp-flacow/downloads
-
       - name: Upload APK to server
-        uses: appleboy/scp-action@v1
-        with:
-          host: ${{ secrets.DEPLOY_HOST }}
-          username: ${{ secrets.DEPLOY_USER }}
-          key: ${{ secrets.DEPLOY_SSH_KEY }}
-          source: flacow.apk
-          target: ~/docker/github/progresapp-flacow/downloads/
-          overwrite: true
+        env:
+          SSH_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
+          SSH_HOST: ${{ secrets.DEPLOY_HOST }}
+          SSH_USER: ${{ secrets.DEPLOY_USER }}
+        run: |
+          echo "$SSH_KEY" > /tmp/deploy_key
+          chmod 600 /tmp/deploy_key
+          ssh -i /tmp/deploy_key -o StrictHostKeyChecking=no "$SSH_USER@$SSH_HOST" \
+            "mkdir -p ~/docker/github/progresapp-flacow/downloads"
+          scp -i /tmp/deploy_key -o StrictHostKeyChecking=no \
+            flacow.apk \
+            "$SSH_USER@$SSH_HOST:~/docker/github/progresapp-flacow/downloads/flacow.apk"
+          rm /tmp/deploy_key


### PR DESCRIPTION
drone-scp 1.8.0 (used by both scp-action v0.1.7 and v1) incorrectly treats ssh-agent 'Identity added' output as an error line, triggering rollback. Use native OpenSSH scp directly — cleaner, no Docker wrapper, no drone-scp bugs.