### PR TITLE
fix(ci): increase Gradle heap to 4g and disable Jetifier

### DIFF
--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -52,6 +52,11 @@ jobs:
           sed -i 's/gradle-8\.8-all/gradle-8.6-all/g' mobile/android/gradle/wrapper/gradle-wrapper.properties
           grep distributionUrl mobile/android/gradle/wrapper/gradle-wrapper.properties
 
+      - name: Increase Gradle JVM heap and disable Jetifier
+        run: |
+          echo "org.gradle.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryError" >> mobile/android/gradle.properties
+          echo "android.enableJetifier=false" >> mobile/android/gradle.properties
+
       - name: Build debug APK
         working-directory: mobile/android
         env:


### PR DESCRIPTION
JetifyTransform runs OOM on hermes-android-0.74.5-debug.aar during Gradle build. RN 0.74.5 already uses AndroidX so Jetifier is not needed.