### PR TITLE
fix(ci): bundle JS into debug APK so it works without Metro

### DIFF
--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -62,7 +62,7 @@ jobs:
         env:
           EXPO_PUBLIC_API_BASE_URL: https://flacow.bfmu.dev/api
           EXPO_PUBLIC_GOOGLE_CLIENT_ID: 198417734095-7lo4l5oqv09ksrufeo5leteo8u803c8t.apps.googleusercontent.com
-        run: ./gradlew :app:assembleDebug --no-daemon
+        run: ./gradlew :app:assembleDebug -PbundleInDebug=true --no-daemon
 
       - name: Prepare APK for upload
         run: |


### PR DESCRIPTION
## Problem

The debug APK was built without the JS bundle packaged inside it. When installed on a real device (no Metro server running), it crashes immediately with:

> Unable to load script. Make sure you're either running Metro or that your bundle 'index.android.bundle' is packaged correctly for release.

## Fix

Added `-PbundleInDebug=true` to the Gradle command. This tells React Native's Gradle plugin to bundle the Metro JS output **into** the APK, so the app works as a standalone installable without needing a dev server.

## Test plan
- [ ] Workflow triggers and builds successfully
- [ ] APK installs and opens on an Android device without the red "Unable to load script" error